### PR TITLE
Update Sample CSV and Field Reference

### DIFF
--- a/docs/documentation/docs/import.md
+++ b/docs/documentation/docs/import.md
@@ -9,10 +9,10 @@ For instance, if there are multiple `Apple (English)` entries, it is inserted on
 -,A,Apple,english,Optional note,english,"",optional-tag1|tag2,"ˈæp.əl|aapl",""
 ^,"","round, red or yellow, edible fruit of a small tree",english,"","","","","",noun
 ^,"","the tree, cultivated in most temperate regions.",english,"","","","","",noun
-^,"","il pomo.",italian,"","","","","",noun
+^,"","il pomo.",italian,"","","","","",sost
 -,A,Application,english,Optional note,italian,"","","aplɪˈkeɪʃ(ə)n",""
 ^,"","the act of putting to a special use or purpose",english,"","","","","",noun
-^,"","le applicazione",italian,"","","","","",noun
+^,"","le applicazione",italian,"","","","","",sost
 
 ```
 
@@ -29,8 +29,8 @@ English and Italian definitions below them.
 | Column | Field            |                                                                                                                                                                                                                                                                                                                                                       |
 |--------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 0      | type             | `-` represents a main entry. `^` under it represents a definition entry.                                                                                                                                                                                                                                                                              |
-| 1      | content          | The entry content (word or phrase).                                                                                                                                                                                                                                                                                                                    |
-| 2      | initial          | The uppercase first character of the entry. Eg: `A` for Apple. If left empty, it is automatically picked up.                                                                                                                                                                                                                                                                                        |
+| 1      | initial          | The uppercase first character of the entry. Eg: `A` for Apple. If left empty, it is automatically picked up.                                                                                                                                                                                                                                                                                                                    |
+| 2      | content          | The entry content (word or phrase).                                                                                                                                                                                                                                                                                        |
 | 3      | language         | Language of the entry (as defined in the config).                                                                                                                                                                                                                                                                                                      |
 | 4      | notes            | Optional notes describing the entry.                                                                                                                                                                                                                                                                                                                          |
 | 5      | tsvector_language | If the language has a built in Postgres fulltext tokenizer, the name of the tokenizer language. For languages that do not have Postgres tokenizers, this should be empty.                                                                                                                                                                             |


### PR DESCRIPTION
While trying to set up dictpress locally and testing CSV imports, I came across the following 2 errors on the [Import Docs](https://dict.press/docs/import/) page:
- The [sample CSV](https://dict.press/docs/import/#sample-csv-format) could not be directly copy-pasted and imported because the sample `config.toml` file has not configured `noun` for Italian language (its defined as *sost* instead).
- The order of fields in the [CSV Field reference](https://dict.press/docs/import/#csv-fields) did not match the order of fields in the Sample CSV. I tried importing the data in the order mentioned in the CSV Field reference and it gave errors.

## Fixes

- Updated the sample CSV to have `definition-types` as *sost* for Italian content.
![Screenshot 2022-06-29 133009](https://user-images.githubusercontent.com/66667161/176385822-f55756ab-088e-4eb5-8bfa-58c34764bdfe.png)

- Updated the order of fields in the CSV Field reference. Column 1 is `initial` and Column 2 is `content`.
![Screenshot 2022-06-29 133027](https://user-images.githubusercontent.com/66667161/176386054-16158efd-d6af-48b0-ae40-6465eec2bfd8.png)

