### PR TITLE
fix(templates.md): changed listmonk to dictpress in doc

### DIFF
--- a/docs/documentation/docs/templates.md
+++ b/docs/documentation/docs/templates.md
@@ -3,7 +3,7 @@ dictpress supports publishing dictionary websites with site themes or templates.
 - [Alar](https://alar.ink) &mdash; Kannada-English dictionary.
 - [Olam](https://olam.in) &mdash; English-Malayalam, Malayalam-Malayalam dictionary.
 
-To setup a dictionary website, use the default theme shipped along with the latest [release](https://github.com/knadh/dictpress/releases) in the `site` directory. When running the listmonk binary, pass the path to the directory to it with the `--site` flag.
+To setup a dictionary website, use the default theme shipped along with the latest [release](https://github.com/knadh/dictpress/releases) in the `site` directory. When running the dictpress binary, pass the path to the directory to it with the `--site` flag.
 
 ```shell
 ./dictpress --site=./site


### PR DESCRIPTION
This is a minor doc change.
changed `listmonk` to `dictpress` in the templates doc.