### PR TITLE
Fix order of column error check in importer

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -179,12 +179,12 @@ func (im *Importer) readEntry(r []string) (entry, error) {
 		return e, fmt.Errorf("unknown language '%s' at column 2", e.Lang)
 	}
 
-	if e.Initial == "" {
-		e.Initial = strings.ToUpper(string(e.Content[0]))
-	}
-
 	if e.Content == "" {
 		return e, fmt.Errorf("empty content (word) at column 1")
+	}
+
+	if e.Initial == "" {
+		e.Initial = strings.ToUpper(string(e.Content[0]))
 	}
 
 	defTypeStr := cleanString(r[9])


### PR DESCRIPTION
To set `e.Initial`, it accesses `e.Content[0]` but if the content is empty this will cause a runtime error. Moving the emptiness check of Content before `e.Initial` column check will fix this.

The error before:
```
2023/07/15 14:54:40 init.go:215: language: english
2023/07/15 14:54:40 init.go:215: language: malayalam
2023/07/15 14:54:40 main.go:172: importing data from ../export.csv ...
panic: runtime error: index out of range [0] with length 0
```

After:
```
2023/07/15 14:56:08 main.go:172: importing data from ../export.csv ...
2023/07/15 14:56:08 main.go:174: error reading line 233: empty content (word) at column 1
exit status 1
```