### PR TITLE
🐛 fix(config.sample.toml) Spell corrected

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -79,7 +79,7 @@ adv = "Adverb"
 conj = "Conjugation"
 
 [lang.italian]
-tokenzier = "italian"
+tokenizer = "italian"
 tokenizer_type = "postgres"
 
 [lang.italian.types]


### PR DESCRIPTION
I duplicated `config.sample.toml` file, and ran the following command:
```sh
/dictpress --site=./site
```
this caused the following error:
```
2024/07/27 01:36:28 main.go:115: reading config: config.toml
2024/07/27 01:36:28 init.go:231: language: english
2024/07/27 01:36:28 init.go:225: unknown custom tokenizer ''
```
by correcting the name from `tokenzier` to `tokenizer` fixed the issue.